### PR TITLE
Fixes segment lengths being set to zero due to incorrect indexing.

### DIFF
--- a/treetools/treeinfo/treeinfo.cpp
+++ b/treetools/treeinfo/treeinfo.cpp
@@ -260,9 +260,9 @@ int main(int argc, char *argv[])
     }
   }
 
-  const int num_attributes = static_cast<int>(forest.trees[0].attributeNames().size());
-  std::vector<std::string> new_attributes = { "volume",    "diameter", "length", "strength", "min_strength",
-                                                    "dominance", "angle",    "children" };
+    const int num_attributes = static_cast<int>(forest.trees[0].attributeNames().size());
+  std::vector<std::string> new_attributes = { "volume", "diameter", "length", "strength", "min_strength",
+                                              "dominance", "angle", "children" };
   if (branch_data.isSet())
   {
     new_attributes.push_back("branch");
@@ -271,20 +271,37 @@ int main(int argc, char *argv[])
     new_attributes.push_back("pos_in_branch");
     new_attributes.push_back("segment_length");
   }
-  const int volume_id = num_attributes + 0;
-  const int diameter_id = num_attributes + 1;
-  const int length_id = num_attributes + 2;
-  const int strength_id = num_attributes + 3;
-  const int min_strength_id = num_attributes + 4;
-  const int dominance_id = num_attributes + 5;
-  const int angle_id = num_attributes + 6;
-  const int children_id = num_attributes + 7;
-  // optional with branch_data
-  const int branch_id = num_tree_attributes + 8;
-  const int branch_order_id = num_tree_attributes + 9;
-  const int extension_id = num_tree_attributes + 10;
-  const int pos_in_branch_id = num_tree_attributes + 11;
-  const int segment_length_id = num_tree_attributes + 12;
+
+  // Indices for new attributes
+  int index = num_attributes; // Start indexing from the number of existing attributes
+  const int volume_id = index++;
+  const int diameter_id = index++;
+  const int length_id = index++;
+  const int strength_id = index++;
+  const int min_strength_id = index++;
+  const int dominance_id = index++;
+  const int angle_id = index++;
+  const int children_id = index++;
+
+  // Declare optional attribute indices
+  int branch_id = -1;
+  int branch_order_id = -1;
+  int extension_id = -1;
+  int pos_in_branch_id = -1;
+  int segment_length_id = -1;
+
+  if (branch_data.isSet())
+  {
+    branch_id = index++;
+    branch_order_id = index++;
+    extension_id = index++;
+    pos_in_branch_id = index++;
+    segment_length_id = index++;
+  }
+
+  // Update the total number of attributes
+  const int total_new_attributes = index - num_attributes;
+  const int new_num_attributes = num_attributes + total_new_attributes; 
 
   auto &att = forest.trees[0].attributeNames();
   for (auto &new_at : new_attributes)


### PR DESCRIPTION
Changed the calculation of segment attribute indices to use num_attributes instead of num_tree_attributes to ensure alignment with the segment.attributes vector. Uses a single index variable to sequentially assign IDs to new attributes.

Resized the attributes vector for each segment to accommodate all new attributes, ensuring that indices are valid and assignments do not exceed bounds.